### PR TITLE
Non-iOS Purple checkout flows (server-side)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,8 @@ curl -X PUT http://<HOST_AND_PORT>/admin/users/<PUBKEY_HEX_FORMAT>/account-uuid 
      -d '{"admin_password": "<ADMIN_PASSWORD_SET_ON_THE_RESPECTIVE_ENV_VARIABLE>", "account_uuid": "<UUID_FOUND_ON_IAP_TRANSACTION>"}'
 ```
 
+### Failures around Lightning Network payments
 
+Ensure you are running Node.js v18.x. Preferably, use the provided nix-shell environment to ensure you are using the correct version of Node.js.
+
+There is a known issue with Node.js v22.x where the `ln.connect_and_init` call does not work with the way things are setup.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "node src/index.js",
     "dev": "TRANSLATION_PROVIDER=mock ENABLE_HTTP_AUTH=\"true\" node src/index.js",
     "dev-debug": "TRANSLATION_PROVIDER=mock ENABLE_HTTP_AUTH=\"true\" node --inspect src/index.js",
+    "dev-debug-cli": "TRANSLATION_PROVIDER=mock ENABLE_HTTP_AUTH=\"true\" node inspect src/index.js",
     "type-check": "tsc --checkJs --allowJs src/*.js --noEmit --skipLibCheck",
     "type-check-path": "tsc --checkJs --allowJs --noEmit --skipLibCheck"
   },

--- a/src/web_auth.js
+++ b/src/web_auth.js
@@ -137,31 +137,31 @@ class WebAuthManager {
   async require_web_auth(req, res, next) {
     const auth_header = req.header('Authorization');
     if (!auth_header) {
-      unauthorized_response(res, 'Unauthorized');
+      unauthorized_response(res, 'Unauthorized, no auth header');
       return;
     }
 
     const [auth_type, token] = auth_header.split(' ');
     if (auth_type !== 'Bearer') {
-      unauthorized_response(res, 'Unauthorized');
+      unauthorized_response(res, 'Unauthorized, invalid auth type');
       return;
     }
 
     if (!token) {
-      unauthorized_response(res, 'Unauthorized');
+      unauthorized_response(res, 'Unauthorized, no token');
       return;
     }
 
     const session_data = await this.dbs.sessions.get(token);
     if (!session_data) {
-      unauthorized_response(res, 'Unauthorized');
+      unauthorized_response(res, 'Unauthorized, invalid token');
       return;
     }
 
     // Check if the session has expired
     if (current_time() - session_data.created_at > this.session_expiry) {
       await this.dbs.sessions.del(token);
-      unauthorized_response(res, 'Unauthorized');
+      unauthorized_response(res, 'Unauthorized, session expired');
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR adds the following:
- New OTP authentication support for LN checkout

## Checklist

- [X] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [X] I have tested the changes in this PR
- [X] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [X] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [X] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: n/a
- [X] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches) **— Not needed, the related issue also depends on https://github.com/damus-io/website/pull/28**

## Test report

### Test 1

**damus-api:** `8bdbd179536da01c3a74b1c8cb5cd7427437c672`
**Node:** v18.20.4, running on NixOS
**Steps:** Run unit tests
**Setup:** Move `.env` file away to avoid env-dependent behavior
**Results:**
- [ ] PASS
- [X] Partial PASS (Passes 5 out of 7 tries)
  - **Details:** There seems to be some pre-existing flakiness on the unit tests. However, I ran the test 7 times and it passed 5 times. Besides, there is not much regression risk with the current changes. Failures are most likely not being caused by this PR.

### Test 2

See test report in https://github.com/damus-io/website/pull/28

## Other notes

- Please see https://github.com/damus-io/website/pull/28 for frontend changes.