### PR TITLE
Separate free and premium notedeck install instructions

### DIFF
--- a/.type_check.txt
+++ b/.type_check.txt
@@ -1,0 +1,91 @@
+src/app_store_receipt_verifier.js(86,57): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+src/index.js(12,32): error TS2307: Cannot find module 'nostr-tools/pool' or its corresponding type declarations.
+src/index.js(36,34): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(37,30): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(38,41): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(39,43): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(40,30): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(41,39): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(42,31): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/index.js(43,30): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DatabaseOptions & { name: string; }'.
+  Type 'string' is not assignable to type '{ name: string; }'.
+src/invoicing.js(187,53): error TS2554: Expected 0 arguments, but got 1.
+src/nip98_auth.js(25,5): error TS2304: Cannot find name 'auth_header_parts'.
+src/nip98_auth.js(26,9): error TS2304: Cannot find name 'auth_header_parts'.
+src/nip98_auth.js(30,9): error TS2304: Cannot find name 'auth_header_parts'.
+src/translate.js(110,36): error TS2538: Type 'Buffer' cannot be used as an index type.
+src/web_auth.js(7,35): error TS2307: Cannot find module 'nostr-tools/pure' or its corresponding type declarations.
+src/web_auth.js(9,48): error TS2307: Cannot find module 'nostr-tools/pool' or its corresponding type declarations.
+src/web_auth.js(11,32): error TS2307: Cannot find module 'nostr-tools/pool' or its corresponding type declarations.
+src/web_auth.js(43,25): error TS2365: Operator '+' cannot be applied to types 'number' and 'string | number'.
+src/web_auth.js(161,9): error TS2365: Operator '>' cannot be applied to types 'number' and 'string | number'.
+test/controllers/mock_iap_controller.js(85,60): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+test/controllers/purple_test_controller.js(49,5): error TS2322: Type 'boolean' is not assignable to type 'string'.
+test/controllers/purple_test_controller.js(55,5): error TS2322: Type 'number' is not assignable to type 'string'.
+test/controllers/purple_test_controller.js(56,5): error TS2322: Type 'number' is not assignable to type 'string'.
+test/controllers/purple_test_controller.js(57,5): error TS2322: Type 'number' is not assignable to type 'string'.
+test/otp_login.test.js(104,90): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+test/otp_login.test.js(134,21): error TS2365: Operator '<' cannot be applied to types 'number' and 'string'.
+test/otp_login.test.js(186,44): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+test/otp_login.test.js(239,44): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+test/transaction_management.test.js(34,45): error TS2345: Argument of type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(63,45): error TS2345: Argument of type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(92,45): error TS2345: Argument of type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(121,45): error TS2345: Argument of type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(150,45): error TS2345: Argument of type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(186,45): error TS2345: Argument of type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(204,45): error TS2345: Argument of type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(230,45): error TS2345: Argument of type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+    Types of property 'type' are incompatible.
+      Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(256,45): error TS2345: Argument of type '({ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; })[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+      Types of property 'type' are incompatible.
+        Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(307,45): error TS2345: Argument of type '({ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; })[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+      Types of property 'type' are incompatible.
+        Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(385,45): error TS2345: Argument of type '({ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; } | { ...; })[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; } | { ...; }' is not assignable to type 'Transaction'.
+    Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+      Types of property 'type' are incompatible.
+        Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(430,45): error TS2345: Argument of type '({ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; })[]' is not assignable to parameter of type 'Transaction[]'.
+  Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; } | { type: string; id: any; start_date: any; end_date: any; purchased_date: number; duration: number; }' is not assignable to type 'Transaction'.
+    Type '{ type: string; id: string; start_date: number; end_date: number; purchased_date: number; duration: any; }' is not assignable to type 'Transaction'.
+      Types of property 'type' are incompatible.
+        Type 'string' is not assignable to type '"iap" | "ln" | "legacy"'.
+test/transaction_management.test.js(436,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+test/translate.test.js(7,27): error TS2305: Module '"./controllers/utils"' has no exported member 'TEST_BASE_URL'.

--- a/.type_check.txt
+++ b/.type_check.txt
@@ -25,7 +25,6 @@ src/web_auth.js(7,35): error TS2307: Cannot find module 'nostr-tools/pure' or it
 src/web_auth.js(9,48): error TS2307: Cannot find module 'nostr-tools/pool' or its corresponding type declarations.
 src/web_auth.js(11,32): error TS2307: Cannot find module 'nostr-tools/pool' or its corresponding type declarations.
 src/web_auth.js(43,25): error TS2365: Operator '+' cannot be applied to types 'number' and 'string | number'.
-src/web_auth.js(161,9): error TS2365: Operator '>' cannot be applied to types 'number' and 'string | number'.
 test/controllers/mock_iap_controller.js(85,60): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 test/controllers/purple_test_controller.js(49,5): error TS2322: Type 'boolean' is not assignable to type 'string'.
 test/controllers/purple_test_controller.js(55,5): error TS2322: Type 'number' is not assignable to type 'string'.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The Damus API backend for Damus Purple and other functionality.
 
 - `DB_PATH`: Path to the folder where to save mdb files.
 - `TESTFLIGHT_URL`: URL for the TestFlight app (optional)
-- `NOTEDECK_INSTALL_MD`: URL for the notedeck installation instructions markdown
-- `NO_AUTH_WALL_NOTEDECK_INSTALL`: Disables the authentication wall for the notedeck installation instructions when set to `"true"`.
+- `NOTEDECK_INSTALL_MD`: Path to the freely available notedeck installation instructions (markdown file)
+- `NOTEDECK_INSTALL_PREMIUM_MD`: Path to the premium notedeck installation instructions (markdown file)
 
 #### Translations
 

--- a/notedeck-install-instructions-premium.md
+++ b/notedeck-install-instructions-premium.md
@@ -1,8 +1,6 @@
 # Installing Notedeck
 
-Thank you for your interest in the Notedeck Alpha release! We are excited to have you try out our software. Below are the instructions for installing Notedeck on your system.
-
-If you are a Purple user, you can now access our beta release! To access the beta install instructions, click [here](/purple/login).
+Thank you for your interest in the Notedeck Beta release! We are excited to have you try out our software. Below are the instructions for installing Notedeck on your system.
 
 If you encounter any issues, please [contact us](support@damus.io).
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dev": "TRANSLATION_PROVIDER=mock ENABLE_HTTP_AUTH=\"true\" node src/index.js",
     "dev-debug": "TRANSLATION_PROVIDER=mock ENABLE_HTTP_AUTH=\"true\" node --inspect src/index.js",
     "dev-debug-cli": "TRANSLATION_PROVIDER=mock ENABLE_HTTP_AUTH=\"true\" node inspect src/index.js",
-    "type-check": "tsc --checkJs --allowJs src/*.js --noEmit --skipLibCheck",
+    "type-check": "tsc --checkJs --allowJs src/*.js test/*.js --noEmit --skipLibCheck",
+    "type-check-compare": "tsc --checkJs --allowJs src/*.js test/*.js --noEmit --skipLibCheck > .type_check.txt",
     "type-check-path": "tsc --checkJs --allowJs --noEmit --skipLibCheck"
   },
   "dependencies": {

--- a/test/controllers/purple_test_client.js
+++ b/test/controllers/purple_test_client.js
@@ -39,8 +39,18 @@ class PurpleTestClient {
   }
 
   /**
+   * Gets the notedeck install instructions
+   *
+   * @param {PurpleTestClientRequestOptions} options - The request options
+   * @returns {Promise<Object>} The response
+   */
+  async get_notedeck_install_instructions(options = {}) {
+    return await this.get('/notedeck-install-instructions', options)
+  }
+
+  /**
    * Gets the product template options.
-   * 
+   *
    * @param {PurpleTestClientRequestOptions} options - The request options
    * @returns {Promise<Object>} The product information
    */

--- a/test/notedeck_install_instructions.test.js
+++ b/test/notedeck_install_instructions.test.js
@@ -1,0 +1,111 @@
+"use strict";
+// @ts-check
+
+const test = require('tap').test;
+const { PurpleTestController } = require('./controllers/purple_test_controller.js');
+const { PURPLE_ONE_MONTH } = require('../src/invoicing.js');
+const { v4: uuidv4 } = require('uuid');
+const path = require('path');
+const fs = require('fs');
+
+const PREMIUM_INSTRUCTIONS = 'premium'
+const FREE_INSTRUCTIONS = 'free'
+
+function get_notedeck_instructions(purple_test_controller, instruction_type) {
+  const installInstructionsPath = instruction_type == PREMIUM_INSTRUCTIONS ? path.resolve(purple_test_controller.env.NOTEDECK_INSTALL_PREMIUM_MD) : path.resolve(purple_test_controller.env.NOTEDECK_INSTALL_MD);
+  return fs.readFileSync(installInstructionsPath, { encoding: 'utf8' });
+}
+
+test('Notedeck free install instructions flow', async (t) => {
+  // Initialize the PurpleTestController
+  const purple_api_controller = await PurpleTestController.new(t);
+
+  // Instantiate a new client
+  const user_pubkey_1 = purple_api_controller.new_client();
+
+  const notedeck_install_response = await purple_api_controller.clients[user_pubkey_1].get_notedeck_install_instructions()
+  t.same(notedeck_install_response.statusCode, 200);
+  t.same(notedeck_install_response.body.value, get_notedeck_instructions(purple_api_controller, FREE_INSTRUCTIONS));
+
+  t.end();
+});
+
+test('Notedeck premium install instructions flow', async (t) => {
+  // Initialize the PurpleTestController
+  const purple_api_controller = await PurpleTestController.new(t);
+
+  // Instantiate a new client
+  const user_pubkey_1 = purple_api_controller.new_client();
+
+  // Let's get them an account
+  await purple_api_controller.ln_flow_buy_subscription(user_pubkey_1, PURPLE_ONE_MONTH);
+
+  // Get the account info
+  const response = await purple_api_controller.clients[user_pubkey_1].get_account();
+  t.same(response.statusCode, 200);
+
+  // Let's login to get a session token
+  // (We could probably get it from the ln subscription flow part, but we are not testing that here, so it's fine)
+  let session_token = await purple_api_controller.login(user_pubkey_1);
+
+  const notedeck_install_response = await purple_api_controller.clients[user_pubkey_1].get_notedeck_install_instructions({ session_token: session_token })
+  t.same(notedeck_install_response.statusCode, 200);
+  t.same(notedeck_install_response.body.value, get_notedeck_instructions(purple_api_controller, PREMIUM_INSTRUCTIONS));
+
+  t.end();
+});
+
+test('Notedeck unauthorized premium install instructions flow', async (t) => {
+  // Initialize the PurpleTestController
+  const purple_api_controller = await PurpleTestController.new(t);
+
+  // Instantiate a new client but don't get an account
+  const user_pubkey_1 = purple_api_controller.new_client();
+
+  // Get the account info
+  const response = await purple_api_controller.clients[user_pubkey_1].get_account();
+  t.same(response.statusCode, 404);
+
+  const notedeck_install_response = await purple_api_controller.clients[user_pubkey_1].get_notedeck_install_instructions({ session_token: "fakesessiontoken" })
+  t.same(notedeck_install_response.statusCode, 200);
+  t.same(notedeck_install_response.body.value, get_notedeck_instructions(purple_api_controller, FREE_INSTRUCTIONS));
+
+  t.end();
+});
+
+
+test('Notedeck expired account install instructions flow', async (t) => {
+  // Initialize the PurpleTestController
+  const purple_api_controller = await PurpleTestController.new(t);
+  purple_api_controller.set_current_time(1706659200)  // 2024-01-31 00:00:00 UTC
+
+  // Instantiate a new client
+  const user_pubkey_1 = purple_api_controller.new_client();
+
+  const initial_account_info_response = await purple_api_controller.clients[user_pubkey_1].get_account();
+  t.same(initial_account_info_response.statusCode, 404);
+
+  // Buy a one month subscription
+  await purple_api_controller.ln_flow_buy_subscription(user_pubkey_1, PURPLE_ONE_MONTH);
+
+  // Check expiry
+  const account_info_response_1 = await purple_api_controller.clients[user_pubkey_1].get_account();
+  t.same(account_info_response_1.statusCode, 200);
+  t.same(account_info_response_1.body.expiry, purple_api_controller.current_time() + 30 * 24 * 60 * 60);
+  t.same(account_info_response_1.body.active, true);
+
+  // Move time forward by 35 days, and make sure the account is not active anymore
+  purple_api_controller.set_current_time(purple_api_controller.current_time() + 35 * 24 * 60 * 60);
+  const account_info_response_2 = await purple_api_controller.clients[user_pubkey_1].get_account();
+  t.same(account_info_response_2.statusCode, 200);
+  t.same(account_info_response_2.body.active, false);
+
+  let session_token = await purple_api_controller.login(user_pubkey_1);
+
+  // Now try to get notedeck instructions
+  const notedeck_install_response = await purple_api_controller.clients[user_pubkey_1].get_notedeck_install_instructions({ session_token: session_token })
+  t.same(notedeck_install_response.statusCode, 200);
+  t.same(notedeck_install_response.body.value, get_notedeck_instructions(purple_api_controller, FREE_INSTRUCTIONS));
+
+  t.end();
+});

--- a/test/router_config.test.js
+++ b/test/router_config.test.js
@@ -67,6 +67,10 @@ test('config_router - Account management routes', async (t) => {
       require_web_auth: async (req, res, next) => {
         req.authorized_pubkey = 'abc123';
         next();
+      },
+      use_web_auth: async (req, res, next) => {
+        req.authorized_pubkey = 'abc123';
+        next();
       }
     }
   };

--- a/test/translate.test.js
+++ b/test/translate.test.js
@@ -188,6 +188,10 @@ async function generate_test_api(t, config) {
       require_web_auth: async (req, res, next) => {
         req.authorized_pubkey = 'abc123';
         next();
+      },
+      use_web_auth: async (req, res, next) => {
+        req.authorized_pubkey = 'abc123';
+        next();
       }
     }
   };


### PR DESCRIPTION
This PR allows us to separate free install instructions from premium/paid ones.


## Test

api: abcdd1f54735183ec40ceb5d0e44d64c1a77ad69
website: 322171d3f9a8c92568b822c54568021495d767e2
Setup: Local testing setup

1. Moved `.env` away temporarily and ran `npm test`. Tests passing
2. Ran `npm run type-check-compare`. No new type warnings or errors
3. Performed functional test:
    1. Went to the page without any login. Confirmed the free instructions appear
    2. Logged in. Confirmed that the paid instructions appear
    3. Forcibly modified session token to "null". Confirmed the free instructions appear
    4. Forcibly modified session token to a random number. Confirmed the free instructions appear
    5. Forcibly deleted session token. Confirmed the free instructions appear
    6. Forcibly recovered session token to a valid one. Confirmed the paid instructions appear
    
    
Results: PASS